### PR TITLE
Mismatch Between Library and Monitoring Platform F1 Score

### DIFF
--- a/lib/ai4hf_passport_models.py
+++ b/lib/ai4hf_passport_models.py
@@ -164,7 +164,7 @@ class EvaluationMeasureType(Enum):
     SPECIFICITY = "specificity"
     FALSE_POSITIVE_RATE = "false_positive_rate"
     FALSE_NEGATIVE_RATE = "false_negative_rate"
-    F1_SCORE = "f1_score"
+    F1_SCORE = "f1"
     ROC = "roc"
     AUC = "auc"
     MAE = "mae"


### PR DESCRIPTION
- F1 Score enumeration is set to 'f1' to fit the existing use in Monitoring Platform